### PR TITLE
fix type casting

### DIFF
--- a/src/common/buffer.c
+++ b/src/common/buffer.c
@@ -95,7 +95,7 @@ buffer_t *buffer_create_with_(void *unused, ...) {
     va_start(va, unused);
     char *mark = va_arg(va, char*);
     while (mark != NULL) {
-        if (HERMES_BUFFER_MAGIC != (int64_t) (int) mark) {
+        if (HERMES_BUFFER_MAGIC != (int64_t) (size_t) mark) {
             buffer_destroy(&res);
             va_end(va);
             return NULL;
@@ -138,7 +138,7 @@ int buffer_extract(buffer_t *buffer, ...) {
     va_start(va, buffer);
     char *mark = va_arg(va, char*);
     for (; mark != NULL; mark = va_arg(va, char*)) {
-        if ((int64_t) (int) mark != HERMES_BUFFER_MAGIC) {
+        if ((int64_t) (size_t) mark != HERMES_BUFFER_MAGIC) {
             va_end(va);
             return BUFFER_INVALID_PARAM;
         }


### PR DESCRIPTION
`HERMES_BUFFER_MAGIC` looks like:
```
#define HERMES_BUFFER_MAGIC 0x0000000026041900
```
it's 64bit value with valuable 32 bits that used as some tag value and can't be cast to int64 on 32-bit system
I added temp cast to architecture dependent size_t that then correctly cast to int64_t
#50 