### PR TITLE
Lagovas/fix rpm version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,10 +259,11 @@ GIT_TAG_STATUS := $(.SHELLSTATUS)
 ifdef GIT_VERSION
 # if has tag then use it
         ifeq ($(GIT_TAG_STATUS),0)
+# <tag>-<commit_count_after_tag>-<last_commit-hash>
                 VERSION = $(shell git describe --tags HEAD | cut -b 1-)
         else
-# otherwise use last commit hash
-                VERSION = 0.5.0-$(shell git describe --always HEAD)
+# <base_version>-<total_commit_count>-<last_commit_hash>
+                VERSION = 0.5.0-$(shell git rev-list --all --count)-$(shell git describe --always HEAD)
         endif
 else
 # if it's not git repo then use date as version
@@ -331,6 +332,7 @@ else ifeq ($(shell lsb_release -is 2> /dev/null),Ubuntu)
 	NAME_SUFFIX = $(VERSION)+$(DEBIAN_CODENAME)_$(DEBIAN_ARCHITECTURE).deb
 	OS_CODENAME = $(shell lsb_release -cs)
 else
+# centos/rpm
 	OS_NAME = $(shell cat /etc/os-release | grep -e "^ID=\".*\"" | cut -d'"' -f2)
 	OS_VERSION = $(shell cat /etc/os-release | grep -i version_id|cut -d'"' -f2)
 	ARCHITECTURE = $(shell arch)


### PR DESCRIPTION
use `_` instead `-` that shouldn't use in rpm versions