### PR TITLE
check exists pointers to functions on server creating stage

### DIFF
--- a/src/credential_store/functions.c
+++ b/src/credential_store/functions.c
@@ -24,6 +24,15 @@
 
 #include <hermes/common/errors.h>
 
+// hm_credential_store_check_backend return HM_SUCCESS if backend hasn't NULL on all functions that expected by interface
+// otherwise HM_FAIL
+uint32_t hm_credential_store_check_backend(hm_cs_db_t *db){
+    if(!(db && db->get_pub)){
+        return false;
+    }
+    return true;
+}
+
 uint32_t hm_credential_store_get_pub_key_by_id(
         hm_cs_db_t *db, const uint8_t *id, const size_t id_length, uint8_t **key, size_t *key_length) {
     if (!db || !(db->get_pub) || !id || !id_length || !key) {

--- a/src/credential_store/functions.h
+++ b/src/credential_store/functions.h
@@ -30,6 +30,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+uint32_t hm_credential_store_check_backend(hm_cs_db_t *db);
+
 #define hm_credential_store_get_pub_key_by_id_NAME "hm_credential_store_get_pub_key_by_id"
 
 uint32_t hm_credential_store_get_pub_key_by_id(

--- a/src/credential_store/server.c
+++ b/src/credential_store/server.c
@@ -35,7 +35,7 @@ struct hm_credential_store_server_type {
 };
 
 hm_credential_store_server_t *hm_credential_store_server_create(hm_rpc_transport_t *transport, hm_cs_db_t *db) {
-    if (!transport || !db) {
+    if (!transport || !db || !hm_credential_store_check_backend(db)) {
         return NULL;
     }
     hm_credential_store_server_t *server = calloc(sizeof(hm_credential_store_server_t), 1);

--- a/src/data_store/functions.c
+++ b/src/data_store/functions.c
@@ -26,6 +26,15 @@
 
 #include <string.h>
 
+// hm_data_store_check_backend return HM_SUCCESS if backend hasn't NULL on all functions that expected by interface
+// otherwise HM_FAIL
+uint32_t hm_data_store_check_backend(hm_ds_db_t *db){
+    if(!(db && db->insert_block && db->insert_block_with_id && db->get_block && db->update_block && db->rem_block)){
+        return false;
+    }
+    return true;
+}
+
 uint32_t hm_data_store_create_block(
         hm_ds_db_t *db,
         const uint8_t *block, const size_t block_length,

--- a/src/data_store/functions.h
+++ b/src/data_store/functions.h
@@ -30,6 +30,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+uint32_t hm_data_store_check_backend(hm_ds_db_t *db);
+
 #define hm_data_store_create_block_NAME "hm_data_store_create_block"
 
 uint32_t hm_data_store_create_block(

--- a/src/data_store/server.c
+++ b/src/data_store/server.c
@@ -35,7 +35,7 @@ struct hm_data_store_server_type {
 };
 
 hm_data_store_server_t *hm_data_store_server_create(hm_rpc_transport_t *transport, hm_ds_db_t *db) {
-    if (!transport || !db) {
+    if (!transport || !db || !hm_data_store_check_backend(db)) {
         return NULL;
     }
     hm_data_store_server_t *server = calloc(sizeof(hm_data_store_server_t), 1);

--- a/src/key_store/functions.c
+++ b/src/key_store/functions.c
@@ -27,6 +27,15 @@
 #include <string.h>
 #include <stdio.h>
 
+// hm_key_store_check_backend return HM_SUCCESS if backend hasn't NULL on all functions that expected by interface
+// otherwise HM_FAIL
+uint32_t hm_key_store_check_backend(hm_ks_db_t *db){
+    if(!(db && db->set_rtoken && db->set_wtoken && db->get_rtoken && db->get_wtoken && db->del_rtoken && db->del_wtoken && db->get_indexed_rights)){
+        return false;
+    }
+    return true;
+}
+
 uint32_t hm_key_store_set_rtoken(
         hm_ks_db_t *db,
         const uint8_t *block_id, const size_t block_id_length,

--- a/src/key_store/functions.h
+++ b/src/key_store/functions.h
@@ -30,6 +30,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+// hm_key_store_check_backend return HM_SUCCESS if backend hasn't NULL on all functions that expected by interface
+// otherwise HM_FAIL
+// should be used on server creation
+uint32_t hm_key_store_check_backend(hm_ks_db_t *db);
+
 #define hm_key_store_set_rtoken_NAME "hm_key_store_set_rtoken"
 
 uint32_t hm_key_store_set_rtoken(

--- a/src/key_store/server.c
+++ b/src/key_store/server.c
@@ -35,7 +35,7 @@ struct hm_key_store_server_type {
 };
 
 hm_key_store_server_t *hm_key_store_server_create(hm_rpc_transport_t *transport, hm_ks_db_t *db) {
-    if (!transport || !db) {
+    if (!transport || !db || !hm_key_store_check_backend(db)) {
         return NULL;
     }
     hm_key_store_server_t *server = calloc(sizeof(hm_key_store_server_t), 1);


### PR DESCRIPTION
function of server creation doesn't check that functions not null even on the stage of registering functions for RPC handlers (i.e. https://github.com/cossacklabs/hermes-core/blob/d8933e4bc32be5644d2c1fcfe1febfdddba97633/src/credential_store/server.c#L48) and app will detect it only on first call of this function (now it will detect on first call of any function)

and it possible when backend will implement just part of the interface (key/credential/data store) and will detect it only when calling this function. server can work long time (i detected it on key rotation function which rarely used) before he detect it