### PR TITLE
deallocate temp buffer in proxy functions

### DIFF
--- a/src/credential_store/functions.c
+++ b/src/credential_store/functions.c
@@ -69,6 +69,7 @@ uint32_t hm_credential_store_get_pub_key_by_id_sync_proxy(
         hm_param_pack_destroy(&out);
         return res;
     }
+    hm_param_pack_destroy(&out);
     return HM_SUCCESS;
 }
 

--- a/src/data_store/functions.c
+++ b/src/data_store/functions.c
@@ -132,6 +132,7 @@ uint32_t hm_data_store_create_block_sync_proxy(
         hm_param_pack_destroy(&out);
         return res;
     }
+    hm_param_pack_destroy(&out);
     return HM_SUCCESS;
 }
 
@@ -195,6 +196,7 @@ uint32_t hm_data_store_read_block_sync_proxy(
         hm_param_pack_destroy(&out);
         return res;
     }
+    hm_param_pack_destroy(&out);
     return HM_SUCCESS;
 }
 

--- a/src/key_store/functions.c
+++ b/src/key_store/functions.c
@@ -259,6 +259,7 @@ uint32_t hm_key_store_get_rtoken_sync_proxy(
         hm_param_pack_destroy(&out);
         return res;
     }
+    hm_param_pack_destroy(&out);
     return HM_SUCCESS;
 }
 
@@ -293,6 +294,7 @@ uint32_t hm_key_store_get_wtoken_sync_proxy(
         hm_param_pack_destroy(&out);
         return res;
     }
+    hm_param_pack_destroy(&out);
     return HM_SUCCESS;
 }
 


### PR DESCRIPTION
after running valgrind I found several memory leaks in proxy functions each new packet from transport [placed into](https://github.com/cossacklabs/hermes-core/blob/master/src/rpc/client.c#L77) temp buffer `out` that then [unwrap into](https://github.com/cossacklabs/hermes-core/blob/master/src/key_store/functions.c#L257) out variables but didn't free after that