### PR TITLE
pass key's owner to revoke access function

### DIFF
--- a/docs/examples/c/mid_hermes_low_level/commands.c
+++ b/docs/examples/c/mid_hermes_low_level/commands.c
@@ -256,7 +256,7 @@ int deny_read(const char* user_id, const char* user_sk, const char* block_file_n
     mid_hermes_ll_user_destroy(&for_u);
     return 1;
   }
-  if(HM_SUCCESS!=mid_hermes_ll_token_del(for_u, bl->id, ks, false)){
+  if(HM_SUCCESS!=mid_hermes_ll_token_del(for_u, u, bl->id, ks, false)){
     mid_hermes_ll_block_destroy(&bl);
     mid_hermes_ll_token_destroy(&wtoken);
     return 1;
@@ -289,7 +289,7 @@ int deny_update(const char* user_id, const char* user_sk, const char* block_file
     mid_hermes_ll_user_destroy(&for_u);
     return 1;
   }
-  if(HM_SUCCESS!=mid_hermes_ll_token_del(for_u, bl->id, ks, true)){
+  if(HM_SUCCESS!=mid_hermes_ll_token_del(for_u, u, bl->id, ks, true)){
     mid_hermes_ll_block_destroy(&bl);
     mid_hermes_ll_token_destroy(&wtoken);
     return 1;

--- a/include/hermes/mid_hermes_ll/mid_hermes_ll_token.h
+++ b/include/hermes/mid_hermes_ll/mid_hermes_ll_token.h
@@ -88,6 +88,7 @@ hermes_status_t mid_hermes_ll_token_save(
 
 hermes_status_t mid_hermes_ll_token_del(
         const mid_hermes_ll_user_t *user,
+        const mid_hermes_ll_user_t *owner,
         const mid_hermes_ll_buffer_t *block_id,
         hermes_key_store_t *key_store,
         bool is_update);

--- a/src/mid_hermes_ll/mid_hermes_ll_token.c
+++ b/src/mid_hermes_ll/mid_hermes_ll_token.c
@@ -171,18 +171,19 @@ hermes_status_t mid_hermes_ll_token_save(
 }
 
 hermes_status_t mid_hermes_ll_token_del(
-        const mid_hermes_ll_user_t *user, const mid_hermes_ll_buffer_t *bl_id,
+        const mid_hermes_ll_user_t *user, const mid_hermes_ll_user_t *owner,
+        const mid_hermes_ll_buffer_t *bl_id,
         hermes_key_store_t *key_store, bool is_update) {
     if (!user || !bl_id || !key_store) {
         return HM_FAIL;
     }
     hermes_status_t res = hermes_key_store_set_wtoken(
             key_store, user->id->data, user->id->length, bl_id->data, bl_id->length, NULL, 0,
-            user->id->data, user->id->length);
+            owner->id->data, owner->id->length);
     if (!is_update) {
         return hermes_key_store_set_rtoken(
                 key_store, user->id->data, user->id->length, bl_id->data, bl_id->length, NULL, 0,
-                user->id->data, user->id->length);
+                owner->id->data, owner->id->length);
     }
     return res;
 }

--- a/src/mid_hermes_ll/mid_hermes_ll_user.c
+++ b/src/mid_hermes_ll/mid_hermes_ll_user.c
@@ -102,11 +102,16 @@ mid_hermes_ll_user_t *mid_hermes_ll_local_user_load_c(
         return NULL;
     }
     mid_hermes_ll_buffer_t *id_buffer = mid_hermes_ll_buffer_create(id, id_length);
+    if(!id_buffer){
+        return NULL;
+    }
     mid_hermes_ll_buffer_t *private_key_buffer = mid_hermes_ll_buffer_create(private_key, private_key_length);
-    mid_hermes_ll_user_t *user = NULL;
-    if (!id_buffer
-        || !private_key_buffer
-        || !(user = mid_hermes_ll_user_load(id_buffer, credential_store))) {
+    if(!private_key_buffer){
+        mid_hermes_ll_buffer_destroy(&id_buffer);
+        return NULL;
+    }
+    mid_hermes_ll_user_t *user = mid_hermes_ll_user_load(id_buffer, credential_store);;
+    if (!user){
         mid_hermes_ll_buffer_destroy(&id_buffer);
         mid_hermes_ll_buffer_destroy(&private_key_buffer);
         return NULL;


### PR DESCRIPTION
keystore server and client interfaces are different. on server side it expect owner id for check that user can revoke access (https://github.com/cossacklabs/hermes-core/blob/master/src/key_store/functions.c#L134) but  owner id not passed on client side (https://github.com/cossacklabs/hermes-core/blob/master/src/mid_hermes/mid_hermes.c#L358) and user_id used as owner_id (https://github.com/cossacklabs/hermes-core/blob/master/src/mid_hermes_ll/mid_hermes_ll_token.c#L181) so we have a situation when userA try to revoke read access of userB that hasn't write access, hermes  check that owner has write access before revoking(but userB used as owner with current mistake) and refuses to do such operation

also added returning block id after creating and did small refactoring of user loading function