### PR TITLE
tests: add empty implementation of `tdestroy` for MacOS

### DIFF
--- a/tests/common/common.c
+++ b/tests/common/common.c
@@ -22,6 +22,12 @@
 #include <stdio.h>
 #include <assert.h>
 
+#ifndef _GNU_SOURCE
+  // empty implementation of tdestroy
+  void tdestroy(void *root, void (*free_node)(void *nodep)) {}
+#endif //_GNU_SOURCE
+
+
 void bin_array_to_hexdecimal_string(const uint8_t* in, const size_t in_length, char* out, size_t out_length){
   assert(in);
   assert(in_length);

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -41,6 +41,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+// this function is not available on MacOS
+#ifndef _GNU_SOURCE
+	void tdestroy(void *root, void (*free_node)(void *nodep));
+#endif //_GNU_SOURCE
+
 void bin_array_to_hexdecimal_string(const uint8_t* in, const size_t in_length, char* out, size_t out_length);
 void hexdecimal_string_to_bin_array(const char* in, const size_t in_length, uint8_t* out, size_t out_length);
 


### PR DESCRIPTION
Currently tests are not compiling on clang-900.0.37 / MacOS because `tdestroy` function is part of GNU utils and is _not available_ on Mac OS.

Instead of implementing it ourselves, I suggest just add empty implementation. Probably, this will lead hermes test suit to leak some data, but I don't think it's important.

I found tdestroy implementation (https://gist.github.com/kulp/3971591#file-tsearch-c-L116) and tested it. It works on a first glance. However, I don't feel that re-implementing `tdestroy` in tests is better than using empty function.