### PR TITLE
tests: decrease amount of data blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tests/db/**
 
 .idea
 cmake-build-debug/**
+
+hermes_env/**

--- a/docs/examples/python/hermes_client.py
+++ b/docs/examples/python/hermes_client.py
@@ -26,7 +26,7 @@ import base64
 import hermes
 
 
-class Trasnport(object):
+class Transport(object):
     def __init__(self, host, port):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.socket.connect((host, port))

--- a/gohermes/mid_hermes.go
+++ b/gohermes/mid_hermes.go
@@ -21,9 +21,7 @@
 package gohermes
 
 /*
-
-#cgo CFLAGS: -I../../include
-#cgo LDFLAGS: -L../../build -lhermes_mid_hermes -lhermes_mid_hermes_ll -lhermes_credential_store -lhermes_data_store -lhermes_key_store -lhermes_rpc -lhermes_common -lthemis -lsoter
+#cgo LDFLAGS: -lhermes_mid_hermes -lhermes_mid_hermes_ll -lhermes_credential_store -lhermes_data_store -lhermes_key_store -lhermes_rpc -lhermes_common -lthemis -lsoter
 #include <hermes/mid_hermes/mid_hermes.h>
 #include "transport.h"
 #include <string.h>

--- a/tests/common/common.c
+++ b/tests/common/common.c
@@ -22,6 +22,12 @@
 #include <stdio.h>
 #include <assert.h>
 
+#ifndef _GNU_SOURCE
+  // empty implementation of tdestroy
+  void tdestroy(void *root, void (*free_node)(void *nodep)) {}
+#endif //_GNU_SOURCE
+
+
 void bin_array_to_hexdecimal_string(const uint8_t* in, const size_t in_length, char* out, size_t out_length){
   assert(in);
   assert(in_length);

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -41,6 +41,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+// this function is not available on MacOS
+#ifndef _GNU_SOURCE
+	void tdestroy(void *root, void (*free_node)(void *nodep));
+#endif //_GNU_SOURCE
+
 void bin_array_to_hexdecimal_string(const uint8_t* in, const size_t in_length, char* out, size_t out_length);
 void hexdecimal_string_to_bin_array(const char* in, const size_t in_length, uint8_t* out, size_t out_length);
 


### PR DESCRIPTION
This is a fun thing.

When I run tests on Mac OS, I got `bus error: 10` when testing `mid_hermes` suit. 

[`Bus error`](http://www1.udel.edu/CIS/181/pconrad/05S/examples/segfault/readme.txt) is similar to `seg fault` error, they both about memory allocation.

I see bus error when `MAX_BLOCKS_IN_TESTS` is more than 160 (e.g. 192), but I don't know how exactly changing block number corrupts memory allocation. I would like to see the results of successful running this test suit on other environments. 

What do you think?

If not decreasing the block value, we should provide an explanation text in Wiki, smth like 'what to do if testing failed'. 