### PR TITLE
small updates in tutorials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tests/db/**
 
 .idea
 cmake-build-debug/**
+
+hermes_env/**

--- a/docs/examples/python/hermes_client.py
+++ b/docs/examples/python/hermes_client.py
@@ -26,7 +26,7 @@ import base64
 import hermes
 
 
-class Trasnport(object):
+class Transport(object):
     def __init__(self, host, port):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.socket.connect((host, port))

--- a/gohermes/mid_hermes.go
+++ b/gohermes/mid_hermes.go
@@ -21,9 +21,7 @@
 package gohermes
 
 /*
-
-#cgo CFLAGS: -I../../include
-#cgo LDFLAGS: -L../../build -lhermes_mid_hermes -lhermes_mid_hermes_ll -lhermes_credential_store -lhermes_data_store -lhermes_key_store -lhermes_rpc -lhermes_common -lthemis -lsoter
+#cgo LDFLAGS: -lhermes_mid_hermes -lhermes_mid_hermes_ll -lhermes_credential_store -lhermes_data_store -lhermes_key_store -lhermes_rpc -lhermes_common -lthemis -lsoter
 #include <hermes/mid_hermes/mid_hermes.h>
 #include "transport.h"
 #include <string.h>


### PR DESCRIPTION
While playing with python / go tutorials:

- fix typo in Python example
- remove relative path to `build` and `include` folders from goHermes
- add `hermes_env` to gitignore