### PR TITLE
fix makefile for credential store service

### DIFF
--- a/docs/examples/c/mid_hermes/credential_store_service/Makefile
+++ b/docs/examples/c/mid_hermes/credential_store_service/Makefile
@@ -2,6 +2,7 @@ all:
 	gcc -g -I../../../../../include -L../../../../../build  \
 	main.c \
 	../common/transport.c \
+	../common/session_callback.c \
 	../common/credential_store_client.c \
 	db.c \
 	../../utils/utils.c \


### PR DESCRIPTION
Otherwise `make` fails