### PR TITLE
null pointers after free them

### DIFF
--- a/src/common/buffer.c
+++ b/src/common/buffer.c
@@ -191,6 +191,7 @@ int buffer_destroy(buffer_t **buffer) {
         (*buffer)->data_.data = NULL;
     }
     free(*buffer);
+    *buffer = NULL;
     return BUFFER_SUCCESS;
 }
 

--- a/src/common/hm_hash_table.c
+++ b/src/common/hm_hash_table.c
@@ -66,6 +66,7 @@ uint32_t hm_hash_table_entry_destroy(hm_hash_table_entry_t *entry) {
     free(entry->key);
     free(entry->val);
     free(entry);
+    entry = NULL;
     return HM_SUCCESS;
 }
 

--- a/src/key_store/functions.c
+++ b/src/key_store/functions.c
@@ -173,6 +173,8 @@ uint32_t hm_key_store_del_rtoken(
             &test_id, &test_id_length)) {
         return HM_FAIL;
     }
+    free(test_token);
+    free(test_id);
     return db->del_rtoken(db->user_data, block_id, block_id_length, user_id, user_id_length, owner_id, owner_id_length);
 }
 
@@ -203,6 +205,8 @@ uint32_t hm_key_store_del_wtoken(
             &test_id, &test_id_length)) {
         return HM_FAIL;
     }
+    free(test_token);
+    free(test_id);
     return db->del_wtoken(db->user_data, block_id, block_id_length, user_id, user_id_length, owner_id, owner_id_length);
 }
 

--- a/src/mid_hermes_ll/mid_hermes_ll_buffer.c
+++ b/src/mid_hermes_ll/mid_hermes_ll_buffer.c
@@ -102,6 +102,8 @@ hermes_status_t mid_hermes_ll_buffer_destroy(mid_hermes_ll_buffer_t** buffer){
   HERMES_CHECK_IN_PARAM(*buffer);
   free((*buffer)->data);
   free(*buffer);
+  (*buffer)->data=NULL;
+  (*buffer)->length=0;
   *buffer=NULL;
   return HM_SUCCESS;
 }

--- a/src/rpc/param_pack.c
+++ b/src/rpc/param_pack.c
@@ -106,6 +106,7 @@ uint32_t hm_param_pack_destroy(hm_param_pack_t** pack){
   }
   if((*pack)->readed){
     free((*pack)->whole_data);
+    (*pack)->whole_data = NULL;
   } else {
     while((*pack)->param_count){
       switch((*pack)->nodes[(*pack)->param_count-1].type){
@@ -120,6 +121,7 @@ uint32_t hm_param_pack_destroy(hm_param_pack_t** pack){
     }
   }
   free(*pack);
+  *pack=NULL;
   return HM_SUCCESS;
 }
 


### PR DESCRIPTION
after discussion with @Lagovas we got a thought that setting freed pointers to NULL is a good practice for cases where pointer is input param.

P.S. nice faq :)
http://c-faq.com/null/