### PR TITLE
zeroing buffer->data instead of buffer->block

### DIFF
--- a/src/mid_hermes_ll/mid_hermes_ll_block.c
+++ b/src/mid_hermes_ll/mid_hermes_ll_block.c
@@ -221,7 +221,7 @@ mid_hermes_ll_block_t *mid_hermes_ll_block_rotate(mid_hermes_ll_block_t *bl, mid
     mid_hermes_ll_token_destroy(&(bl->wtoken));
     mid_hermes_ll_buffer_destroy_secure(&rt);
     mid_hermes_ll_buffer_destroy_secure(&wt);
-    mid_hermes_ll_token_destroy(&(bl->block));
+    mid_hermes_ll_buffer_destroy(&(bl->block));
     bl->rtoken = new_rtoken;
     bl->wtoken = new_wtoken;
     bl->block = new_block;


### PR DESCRIPTION
We found that `data` contains unencrypted data, so it should be removed securely too