### PR TITLE
fix make

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,6 @@ dependencies:
 
   override:
     - make
-    - make clean
     - sudo make install
 
 test:


### PR DESCRIPTION
It looks like our circle ci build is not the best :D

master branch is not working due to link errors

first one:

```
build/obj/secure_transport/utils.o [OK]
-n link 
secure_transport_shared        [ERRORS]
cc -shared -o build/libhermes_secure_transport.dylib build/obj/secure_transport/session_callback.o build/obj/secure_transport/transport.o build/obj/secure_transport/utils.o -Lbuild -lthemis -lsoter
Undefined symbols for architecture x86_64:
  "_hm_credential_store_client_sync_call_get_pub_key_by_id", referenced from:
      _get_public_key_for_id_from_remote_credential_store_callback in session_callback.o
  "_hm_credential_store_client_sync_create", referenced from:
      _get_session_callback_with_remote_credential_store in session_callback.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [secure_transport_shared] Error 1
```