### PR TITLE
fixing pyhermes accroding to clang style

### DIFF
--- a/pyhermes/py_secure_transport.c
+++ b/pyhermes/py_secure_transport.c
@@ -19,13 +19,9 @@
 */
 
 
-#include <Python.h>
 
-#include <hermes/mid_hermes/mid_hermes.h>
-#include <hermes/secure_transport/transport.h>
+
 #include "py_secure_transport.h"
-#include "transport.h"
-#include "py_transport_wrapper.h"
 
 extern PyObject *HermesTransportError;
 

--- a/pyhermes/py_secure_transport.h
+++ b/pyhermes/py_secure_transport.h
@@ -21,6 +21,12 @@
 #ifndef HERMES_CORE_SECURE_TRANSPORT_H
 #define HERMES_CORE_SECURE_TRANSPORT_H
 
+#include <Python.h>
+#include <hermes/secure_transport/transport.h>
+#include "transport.h"
+#include "py_transport_wrapper.h"
+
+
 typedef struct pyhermes_SecureHermesTransportObject_type {
     PyObject_HEAD
     hm_rpc_transport_t *hermes_transport;

--- a/pyhermes/py_transport_wrapper.c
+++ b/pyhermes/py_transport_wrapper.c
@@ -18,9 +18,6 @@
 *
 */
 
-#include <Python.h>
-#include <hermes/rpc/transport.h>
-#include "transport.h"
 #include "py_transport_wrapper.h"
 
 PyObject *HermesTransportWrapper_FromHmRpcTransport(hm_rpc_transport_t *transport) {

--- a/pyhermes/py_transport_wrapper.h
+++ b/pyhermes/py_transport_wrapper.h
@@ -21,12 +21,16 @@
 #ifndef HERMES_CORE_PY_TRANSPORT_WRAPPER_H
 #define HERMES_CORE_PY_TRANSPORT_WRAPPER_H
 
+#include <Python.h>
+#include <hermes/rpc/transport.h>
+#include "transport.h"
+
 typedef struct pyhermes_HermesTransportWrapperObject_type {
     PyObject_HEAD
     hm_rpc_transport_t *hermes_transport;
 } pyhermes_HermesTransportWrapperObject_t;
 
-PyTypeObject pyhermes_HermesTransportWrapperType;
+extern PyTypeObject pyhermes_HermesTransportWrapperType;
 
 PyObject *HermesTransportWrapper_FromHmRpcTransport(hm_rpc_transport_t *transport);
 

--- a/pyhermes/transport.h
+++ b/pyhermes/transport.h
@@ -26,7 +26,7 @@
 #include <Python.h>
 #include <hermes/rpc/transport.h>
 
-PyObject *HermesTransportError;
+extern PyObject *HermesTransportError;
 
 hm_rpc_transport_t *transport_create(PyObject *transport);
 


### PR DESCRIPTION
Because `clang Apple clang-900.0.38` doesn't like duplicate objects :)

Previously compilation failed with

<details>
<summary> Error log here</summary>
<p style="font-family:'Lucida Console', monospace">
python3 setup.py install
running install
running build
running build_ext
building 'pyhermes' extension
creating build
creating build/temp.macosx-10.11-x86_64-3.5
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I../include -I/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/include/python3.5m -c pyhermes.c -o build/temp.macosx-10.11-x86_64-3.5/pyhermes.o
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I../include -I/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/include/python3.5m -c transport.c -o build/temp.macosx-10.11-x86_64-3.5/transport.o
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I../include -I/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/include/python3.5m -c py_secure_transport.c -o build/temp.macosx-10.11-x86_64-3.5/py_secure_transport.o
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I../include -I/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/include/python3.5m -c py_midhermes.c -o build/temp.macosx-10.11-x86_64-3.5/py_midhermes.o
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I../include -I/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/include/python3.5m -c py_transport_wrapper.c -o build/temp.macosx-10.11-x86_64-3.5/py_transport_wrapper.o
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I../include -I/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/include/python3.5m -c py_transport.c -o build/temp.macosx-10.11-x86_64-3.5/py_transport.o
creating build/lib.macosx-10.11-x86_64-3.5
clang -bundle -undefined dynamic_lookup build/temp.macosx-10.11-x86_64-3.5/pyhermes.o build/temp.macosx-10.11-x86_64-3.5/transport.o build/temp.macosx-10.11-x86_64-3.5/py_secure_transport.o build/temp.macosx-10.11-x86_64-3.5/py_midhermes.o build/temp.macosx-10.11-x86_64-3.5/py_transport_wrapper.o build/temp.macosx-10.11-x86_64-3.5/py_transport.o -L../build -lhermes_mid_hermes -lhermes_mid_hermes_ll -lhermes_credential_store -lhermes_data_store -lhermes_key_store -lhermes_rpc -lhermes_common -lthemis -lsoter -lhermes_secure_transport -o build/lib.macosx-10.11-x86_64-3.5/pyhermes.cpython-35m-darwin.so
clang -bundle -undefined dynamic_lookup build/temp.macosx-10.11-x86_64-3.5/pyhermes.o build/temp.macosx-10.11-x86_64-3.5/transport.o build/temp.macosx-10.11-x86_64-3.5/py_secure_transport.o build/temp.macosx-10.11-x86_64-3.5/py_midhermes.o build/temp.macosx-10.11-x86_64-3.5/py_transport_wrapper.o build/temp.macosx-10.11-x86_64-3.5/py_transport.o -L../build -lhermes_mid_hermes -lhermes_mid_hermes_ll -lhermes_credential_store -lhermes_data_store -lhermes_key_store -lhermes_rpc -lhermes_common -lthemis -lsoter -lhermes_secure_transport -o build/lib.macosx-10.11-x86_64-3.5/pyhermes.cpython-35m-darwin.so
duplicate symbol _HermesTransportError in:
    build/temp.macosx-10.11-x86_64-3.5/transport.o
    build/temp.macosx-10.11-x86_64-3.5/py_secure_transport.o
duplicate symbol _HermesTransportError in:
    build/temp.macosx-10.11-x86_64-3.5/transport.o
    build/temp.macosx-10.11-x86_64-3.5/py_midhermes.o
duplicate symbol _pyhermes_HermesTransportWrapperType in:
    build/temp.macosx-10.11-x86_64-3.5/py_secure_transport.o
    build/temp.macosx-10.11-x86_64-3.5/py_midhermes.o
duplicate symbol _HermesTransportError in:
    build/temp.macosx-10.11-x86_64-3.5/transport.o
    build/temp.macosx-10.11-x86_64-3.5/py_transport_wrapper.o
duplicate symbol _pyhermes_HermesTransportWrapperType in:
    build/temp.macosx-10.11-x86_64-3.5/py_secure_transport.o
    build/temp.macosx-10.11-x86_64-3.5/py_transport_wrapper.o
duplicate symbol _HermesTransportError in:
    build/temp.macosx-10.11-x86_64-3.5/transport.o
    build/temp.macosx-10.11-x86_64-3.5/py_transport.o
duplicate symbol _pyhermes_HermesTransportWrapperType in:
    build/temp.macosx-10.11-x86_64-3.5/py_secure_transport.o
    build/temp.macosx-10.11-x86_64-3.5/py_transport.o
ld: 7 duplicate symbols for architecture x86_64
</p>
</details>