### PR TITLE
fix compilation errors with strict mode

### DIFF
--- a/docs/examples/c/mid_hermes_low_level/main.c
+++ b/docs/examples/c/mid_hermes_low_level/main.c
@@ -153,5 +153,5 @@ int main(int argc, char *argv[]) {
         return FAIL;
     }
     finalize();
-    return FAIL;
+    return SUCCESS;
 }

--- a/include/hermes/common/buffer.h
+++ b/include/hermes/common/buffer.h
@@ -31,14 +31,14 @@
 #define BUFFER_SUCCESS HM_SUCCESS
 #define BUFFER_INVALID_PARAM HM_INVALID_PARAMETER
 #define BUFFER_BAD_ALLOC HM_BAD_ALLOC
-#define BUFFER_AT_END -4
-#define BUFFER_INCORRECT_BLOCK_TYPE -5
-#define BUFFER_CORRUPTED -6
-#define BUFFER_WRITE_READ_ONLY -7
+#define BUFFER_AT_END (-4)
+#define BUFFER_INCORRECT_BLOCK_TYPE (-5)
+#define BUFFER_CORRUPTED (-6)
+#define BUFFER_WRITE_READ_ONLY (-7)
 
 typedef struct buffer_t_ buffer_t;
 
-buffer_t *buffer_create();
+buffer_t *buffer_create(void);
 
 buffer_t *buffer_create_with_(void *unused, ...);
 

--- a/include/hermes/common/hash_table.h
+++ b/include/hermes/common/hash_table.h
@@ -28,7 +28,7 @@
 
 typedef struct hm_hash_table_type hm_hash_table_t;
 
-hm_hash_table_t* hm_hash_table_create();
+hm_hash_table_t* hm_hash_table_create(void);
 uint32_t hm_hash_table_destroy(hm_hash_table_t** table);
 
 uint32_t hm_hash_table_set(hm_hash_table_t* table, const uint8_t* key, const size_t key_length, const uint8_t* val, const size_t val_length);

--- a/include/hermes/mid_hermes_ll/mid_hermes_ll_rights_list.h
+++ b/include/hermes/mid_hermes_ll/mid_hermes_ll_rights_list.h
@@ -47,7 +47,7 @@ typedef struct mid_hermes_ll_rights_list_type {
     size_t len;
 } mid_hermes_ll_rights_list_t;
 
-mid_hermes_ll_rights_list_t *mid_hermes_ll_rights_list_create();
+mid_hermes_ll_rights_list_t *mid_hermes_ll_rights_list_create(void);
 
 hermes_status_t mid_hermes_ll_rights_list_rpush(
         mid_hermes_ll_rights_list_t *rights_list, mid_hermes_ll_rights_list_node_t *rights_node);

--- a/include/hermes/rpc/buffers_list.h
+++ b/include/hermes/rpc/buffers_list.h
@@ -40,7 +40,7 @@ typedef struct hm_buffers_list_type {
     hm_buffers_list_node_t *first;
 } hm_buffers_list_t;
 
-hm_buffers_list_t *hm_buffers_list_create();
+hm_buffers_list_t *hm_buffers_list_create(void);
 
 hm_buffers_list_t *hm_buffers_list_extract(const uint8_t *data, const size_t length);
 
@@ -57,9 +57,9 @@ typedef struct hm_buffers_list_iterator_type hm_buffers_list_iterator_t;
 struct hm_buffers_list_iterator_type {
     hm_buffers_list_node_t *curr;
 
-    const uint8_t *(*data)(hm_buffers_list_iterator_t *iterator);
+    uint8_t *(*data)(hm_buffers_list_iterator_t *iterator);
 
-    const size_t (*size)(hm_buffers_list_iterator_t *iterator);
+    size_t (*size)(hm_buffers_list_iterator_t *iterator);
 
     bool (*next)(hm_buffers_list_iterator_t *iterator);
 };

--- a/include/hermes/rpc/param_pack.h
+++ b/include/hermes/rpc/param_pack.h
@@ -34,7 +34,7 @@ typedef uint32_t (*send_rouitine_t)(void* user_data, const uint8_t* buffer_to_se
 // if really readed less than buffer_to_receive_length bytes need return error!!!
 typedef uint32_t (*recv_rouitine_t)(void* user_data, uint8_t* buffer_to_receive, const size_t buffer_to_receive_length);
 
-hm_param_pack_t* hm_param_pack_create();
+hm_param_pack_t* hm_param_pack_create(void);
 
 hm_param_pack_t* hm_param_pack_create_(void* unused, ...);
 uint32_t hm_param_pack_extract_(hm_param_pack_t* pack, ...);

--- a/src/common/buffer.c
+++ b/src/common/buffer.c
@@ -29,7 +29,7 @@
 #include <hermes/common/errors.h>
 
 
-#define BUFFER_BLOCK_CAPACITY_DEFAULT 1024*10
+#define BUFFER_BLOCK_CAPACITY_DEFAULT (1024*10)
 
 struct buffer_t_ {
     size_t capacity_;
@@ -60,7 +60,7 @@ int buffer_realloc_(buffer_t *buffer, const size_t size) {
     return BUFFER_SUCCESS;
 }
 
-buffer_t *buffer_create() {
+buffer_t *buffer_create(void) {
     buffer_t *buffer = malloc(sizeof *buffer);
     assert(buffer);
     buffer->capacity_ = 1;

--- a/src/common/hm_hash_table.c
+++ b/src/common/hm_hash_table.c
@@ -73,7 +73,7 @@ uint32_t hm_hash_table_entry_destroy(hm_hash_table_entry_t *entry) {
 int hm_hash_(const uint8_t *key, const size_t key_length) {
     //djb2 function.
     unsigned long hash = 5381;
-    int i = 0;
+    size_t i = 0;
     for (; i < key_length; ++i) {
         hash = ((hash << 5) + hash) + key[i];
     }
@@ -84,7 +84,7 @@ struct hm_hash_table_type {
     hm_hash_table_entry_t *t[HM_HASH_TABLE_CAP];
 };
 
-hm_hash_table_t *hm_hash_table_create() {
+hm_hash_table_t *hm_hash_table_create(void) {
     hm_hash_table_t *table = calloc(sizeof(hm_hash_table_t), 1);
     assert(table);
     return table;

--- a/src/mid_hermes_ll/mid_hermes_ll_rights_list.c
+++ b/src/mid_hermes_ll/mid_hermes_ll_rights_list.c
@@ -48,7 +48,7 @@ hermes_status_t mid_hermes_ll_rights_list_node_destroy(mid_hermes_ll_rights_list
     return HM_SUCCESS;
 }
 
-mid_hermes_ll_rights_list_t *mid_hermes_ll_rights_list_create() {
+mid_hermes_ll_rights_list_t *mid_hermes_ll_rights_list_create(void) {
     mid_hermes_ll_rights_list_t *list = calloc(1, sizeof(mid_hermes_ll_rights_list_t));
     assert(list);
     return list;

--- a/src/rpc/buffers_list.c
+++ b/src/rpc/buffers_list.c
@@ -26,7 +26,7 @@
 #include <assert.h>
 #include <string.h>
 
-hm_buffers_list_t *hm_buffers_list_create() {
+hm_buffers_list_t *hm_buffers_list_create(void) {
     hm_buffers_list_t *list = calloc(1, sizeof(hm_buffers_list_t));
     assert(list);
     return list;
@@ -148,14 +148,14 @@ hermes_status_t hm_buffers_list_destroy(hm_buffers_list_t **buffers_list) {
     return HM_SUCCESS;
 }
 
-const uint8_t *hm_buffers_list_iterator_get_data(hm_buffers_list_iterator_t *iterator) {
+uint8_t *hm_buffers_list_iterator_get_data(hm_buffers_list_iterator_t *iterator) {
     if (!iterator || !(iterator->curr)) {
         return NULL;
     }
     return iterator->curr->data;
 }
 
-const size_t hm_buffers_list_iterator_get_size(hm_buffers_list_iterator_t *iterator) {
+size_t hm_buffers_list_iterator_get_size(hm_buffers_list_iterator_t *iterator) {
     if (!iterator || !(iterator->curr)) {
         return 0;
     }

--- a/src/rpc/param_pack.c
+++ b/src/rpc/param_pack.c
@@ -51,7 +51,7 @@ struct hm_param_pack_type{
   hm_param_pack_node_t nodes[HM_PARAM_PACK_MAX_PARAMS];
 };
 
-hm_param_pack_t* hm_param_pack_create(){
+hm_param_pack_t* hm_param_pack_create(void){
   hm_param_pack_t* res = calloc(1, sizeof(hm_param_pack_t));
   assert(res);
   return res;

--- a/src/secure_transport/session_callback.c
+++ b/src/secure_transport/session_callback.c
@@ -37,7 +37,7 @@ int get_public_key_for_id_from_remote_credential_store_callback(
     free(temp_buffer);
     temp_buffer = NULL;
     return THEMIS_SUCCESS;
-};
+}
 
 int get_public_key_for_id_from_local_credential_store_callback(
         const void *id, size_t id_length, void *key_buffer, size_t key_buffer_length, void *user_data) {
@@ -54,7 +54,7 @@ int get_public_key_for_id_from_local_credential_store_callback(
     free(temp_buffer);
     temp_buffer = NULL;
     return THEMIS_SUCCESS;
-};
+}
 
 
 secure_session_user_callbacks_t* get_session_callback_with_remote_credential_store(hm_rpc_transport_t *transport){

--- a/src/secure_transport/transport.c
+++ b/src/secure_transport/transport.c
@@ -79,7 +79,7 @@ int get_public_key_for_id_wrapper(const void *id, size_t id_length, void *key_bu
         return THEMIS_SUCCESS;
     }
     return THEMIS_FAIL;
-};
+}
 
 // hermes_transport_send encrypt buffer with secure session and send data with <send_data> function
 // implement hermes transport interface
@@ -104,7 +104,7 @@ uint32_t hermes_transport_send(void *transport_, const uint8_t *buffer, const si
     };
     free(wrapped_buffer);
     return HM_SUCCESS;
-};
+}
 
 // hermes_transport_receive read data from transport with <read_data_size> and <read_data> functions,
 // unwrap with secure_session and return when read size == buffer_length
@@ -150,7 +150,7 @@ uint32_t hermes_transport_receive(void *transport_, uint8_t *buffer, size_t buff
         total_read += unwrapped_size;
     }while(total_read < buffer_length);
     return HM_SUCCESS;
-};
+}
 
 // init_secure_session establish secure session using transport
 hermes_status_t init_secure_session(hm_rpc_transport_t* transport, secure_session_t* session, bool is_server){

--- a/src/secure_transport/utils.c
+++ b/src/secure_transport/utils.c
@@ -38,7 +38,7 @@ uint32_t read_data_size(hm_rpc_transport_t* transport){
     }
     data_size = ntohl(data_size);
     return data_size;
-};
+}
 // read_data read data_length from transport and return HM_FAIL on transport HM_FAIL response or if read count
 // of bytes not equal to data_length
 uint32_t read_data(uint8_t* data, size_t data_length, hm_rpc_transport_t* transport){


### PR DESCRIPTION
fix next errors:
* `error: ISO C does not allow extra ‘;’ outside of a function [-Werror=pedantic]` - with `;` after braces
* `error: function declaration isn’t a prototype [-Werror=strict-prototypes]` with function prototype like `void somefunc()` 
* `error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]` when function return type has `const`