### PR TITLE
fix redefined error

### DIFF
--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -38,7 +38,7 @@
 #define TEST_SUCCESS 0
 #define TEST_FAIL 1
 
-#define UNUSED(expr) (void)(expr)
+#define UNUSED(x) (void)(x)
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/common/test_utils.h
+++ b/tests/common/test_utils.h
@@ -31,7 +31,7 @@
 extern "C"{
 #endif
 
-#define UNUSED(expr) (void)(expr)
+#define UNUSED(x) (void)(x)
 
 typedef int test_utils_status_t;
 


### PR DESCRIPTION
use UNUSED define the same as in themis/soter/soter_error.h to fix redefinition error