### PR TITLE
encapsulate wrappers from local midhermes

### DIFF
--- a/gohermes/midhermes/local/local_mid_hermes.go
+++ b/gohermes/midhermes/local/local_mid_hermes.go
@@ -59,7 +59,7 @@ func NewLocalMidHermes(id []byte, private_key []byte, credentialStore gohermes.C
 		(*C.uint8_t)(unsafe.Pointer(&private_key[0])), C.size_t(len(private_key)),
 		(*C.hermes_key_store_t)(unsafe.Pointer(keystoreWrapper.GetHermesKeyStore())),
 		(*C.hermes_data_store_t)(unsafe.Pointer(datastoreWrapper.GetHermesDataStore())),
-			(*C.hermes_credential_store_t)(unsafe.Pointer(credentialWrapper.GetHermesCredentialStore())))
+		(*C.hermes_credential_store_t)(unsafe.Pointer(credentialWrapper.GetHermesCredentialStore())))
 	if nil == mh.mid_hermes {
 		return mh, errors.New("LocalMidHermes object creation error")
 	}

--- a/gohermes/midhermes/local/local_mid_hermes_test.go
+++ b/gohermes/midhermes/local/local_mid_hermes_test.go
@@ -106,23 +106,7 @@ func (store *SimpleDataStore) DeleteBlock(id []byte, oldMac []byte) error { retu
 func (store *SimpleDataStore) Close() error { return nil }
 
 func TestNewLocalMidHermes(t *testing.T) {
-	credentialStore := &SimpleCredentialStore{}
-	midhermesCredentialStore, err := NewCredentialStore(credentialStore)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	midhermesKeyStore, err := NewKeyStore(&SimpleKeyStore{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	midhermesDataStore, err := NewDataStore(&SimpleDataStore{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	hermesWrapper, err := NewLocalMidHermes(userId, userPrivateKey, midhermesCredentialStore, midhermesKeyStore, midhermesDataStore)
+	hermesWrapper, err := NewLocalMidHermes(userId, userPrivateKey, &SimpleCredentialStore{}, &SimpleKeyStore{}, &SimpleDataStore{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
don't require pass wrappers from local.midhermes and expect only interfaces in initialization